### PR TITLE
Weekly summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,55 @@ Retrieves all playthroughs for a given player.
     ]
 ```
 
+### Weekly Summary
+
+Retrieve a summary of players’ weekly playthrough statistics, with optional date filtering and sorting.
+
+**GET** `/api/v1/weekly_summary`
+
+Returns a summary of players’ playthroughs for a specified week or the current week by default.
+
+#### Request Parameters
+
+| Parameter   | Type   | Description                                                 | Default       |
+| ----------- | ------ | ----------------------------------------------------------- | ------------- |
+| `date`      | string | The date to fetch the week containing this date (ISO 8601). | Current date  |
+| `sort_by`   | string | Field to sort by: `total_score` or `total_duration`.        | `total_score` |
+| `direction` | string | Sort direction: `asc` or `desc`.                            | `desc`        |
+
+Weekly Summary with `date`, sort by `total_score` or `total_duration`
+
+**GET** `api/v1/weekly_summary?date={date}&sort_by={field}&direction={direction}`
+
+**Example CURL:**
+
+```bash
+    curl "http://localhost:3000/api/v1/weekly_summary?date=2025-05-12&sort_by=total_duration&direction=asc"
+```
+
+**Response:**
+
+```json
+    {
+    "week_start_date": "2025-05-12",
+    "week_end_date": "2025-05-18",
+    "player_summaries": [
+        {
+        "player_id": "8c561c6a-6304-4952-9492-2ae6759ac0f5",
+        "player_name": "Yennefer)",
+        "total_score": 400.0,
+        "total_duration": 3400.0
+        },
+        {
+        "player_id": "2fd17a3d-ce8f-40e7-8730-1128f55b79ef",
+        "player_name": "Ciri",
+        "total_score": 500.0,
+        "total_duration": 5000.0
+        }
+    ]
+    }
+```
+
 ## Testing
 
 Run tests with:

--- a/app/blueprints/api/v1/player_summary_blueprint.rb
+++ b/app/blueprints/api/v1/player_summary_blueprint.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class PlayerSummaryBlueprint < Blueprinter::Base
+      fields :player_id, :player_name, :total_score, :total_duration
+    end
+  end
+end

--- a/app/blueprints/api/v1/weekly_summary_blueprint.rb
+++ b/app/blueprints/api/v1/weekly_summary_blueprint.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1
+    class WeeklySummaryBlueprint < Blueprinter::Base
+      fields :week_start_date, :week_end_date
+
+      association :player_summaries, blueprint: Api::V1::PlayerSummaryBlueprint
+    end
+  end
+end

--- a/app/controllers/api/v1/weekly_summary_controller.rb
+++ b/app/controllers/api/v1/weekly_summary_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1
+    class WeeklySummaryController < Api::V1::BaseController
+      def index
+        render json: { message: "Weekly summary" }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/weekly_summary_controller.rb
+++ b/app/controllers/api/v1/weekly_summary_controller.rb
@@ -2,22 +2,31 @@ module Api
   module V1
     class WeeklySummaryController < Api::V1::BaseController
       def index
-        date = parse_date(params[:date]) || Date.current
+        summary = Api::V1::WeeklySummaryService.call(
+          date: parsed_date,
+          sort_by: validated_sort_by,
+          direction: validated_direction
+        )
 
-        summary = Api::V1::WeeklySummaryService.call(date)
         render json: Api::V1::WeeklySummaryBlueprint.render(summary)
       rescue ArgumentError
-        render json: { error: "Invalid date format" }, status: :unprocessable_entity
+        render json: { error: 'Invalid date format' }, status: :unprocessable_entity
       end
 
       private
 
-      def parse_date(date_str)
-        return nil if date_str.blank?
+      def parsed_date
+        return Date.current if params[:date].blank?
 
-        Date.parse(date_str)
-      rescue ArgumentError
-        raise ArgumentError, "Invalid date format"
+        Date.parse(params[:date])
+      end
+
+      def validated_sort_by
+        %w[total_score total_duration].include?(params[:sort_by]) ? params[:sort_by] : 'total_score'
+      end
+
+      def validated_direction
+        %w[asc desc].include?(params[:direction]) ? params[:direction] : 'desc'
       end
     end
   end

--- a/app/controllers/api/v1/weekly_summary_controller.rb
+++ b/app/controllers/api/v1/weekly_summary_controller.rb
@@ -2,7 +2,22 @@ module Api
   module V1
     class WeeklySummaryController < Api::V1::BaseController
       def index
-        render json: { message: "Weekly summary" }
+        date = parse_date(params[:date]) || Date.current
+
+        summary = Api::V1::WeeklySummaryService.call(date)
+        render json: Api::V1::WeeklySummaryBlueprint.render(summary)
+      rescue ArgumentError
+        render json: { error: "Invalid date format" }, status: :unprocessable_entity
+      end
+
+      private
+
+      def parse_date(date_str)
+        return nil if date_str.blank?
+
+        Date.parse(date_str)
+      rescue ArgumentError
+        raise ArgumentError, "Invalid date format"
       end
     end
   end

--- a/app/services/api/v1/weekly_summary_service.rb
+++ b/app/services/api/v1/weekly_summary_service.rb
@@ -1,6 +1,5 @@
 module Api
   module V1
-    require 'benchmark'
     class WeeklySummaryService
       def self.call(date = nil)
         date = normalize_date(date)

--- a/app/services/api/v1/weekly_summary_service.rb
+++ b/app/services/api/v1/weekly_summary_service.rb
@@ -1,0 +1,55 @@
+module Api
+  module V1
+    require 'benchmark'
+    class WeeklySummaryService
+      def self.call(date = nil)
+        date = normalize_date(date)
+        playthroughs = fetch_playthroughs_for_the_week(date)
+        player_summaries = calculate_player_summaries(playthroughs)
+        summarize(date, date.end_of_week, player_summaries)
+      end
+
+      class << self
+        private
+
+        def normalize_date(date)
+          date ||= Date.current
+          date.beginning_of_week(:monday)
+        end
+
+        def fetch_playthroughs_for_the_week(date)
+          end_date = date.end_of_week
+          Playthrough.where(started_at: date.beginning_of_day..end_date.end_of_day)
+        end
+
+        def calculate_player_summaries(playthroughs) # rubocop:disable Metrics/MethodLength
+          playthroughs
+            .joins(:player)
+            .group('players.id', 'players.name')
+            .select(
+              'players.id as player_id',
+              'players.name as player_name',
+              'SUM(playthroughs.score) as total_score',
+              'SUM(playthroughs.time_spent) as total_duration'
+            )
+            .map do |result|
+              {
+                player_id: result.player_id,
+                player_name: result.player_name,
+                total_score: result.total_score.to_f,
+                total_duration: result.total_duration.to_f
+              }
+            end
+        end
+
+        def summarize(start_date, end_date, summaries)
+          {
+            week_start_date: start_date,
+            week_end_date: end_date,
+            player_summaries: summaries
+          }
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,13 +5,17 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # Defines the root path route ("/")
-  # root "posts#index"
   namespace :api do
     namespace :v1 do
       resources :players, only: [:create] do
         resources :playthroughs, only: %i[index create]
       end
+    end
+  end
+
+  namespace :api do
+    namespace :v1 do
+      get 'weekly_summary', to: 'weekly_summary#index'
     end
   end
 end

--- a/db/migrate/20250518112310_add_index_to_playthroughs_started_at.rb
+++ b/db/migrate/20250518112310_add_index_to_playthroughs_started_at.rb
@@ -1,0 +1,5 @@
+class AddIndexToPlaythroughsStartedAt < ActiveRecord::Migration[8.0]
+  def change
+    add_index :playthroughs, [:started_at, :player_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_17_154407) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_18_112310) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -31,6 +31,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_17_154407) do
     t.index ["player_id", "score"], name: "index_playthroughs_on_player_id_and_score"
     t.index ["player_id", "started_at"], name: "index_playthroughs_on_player_id_and_started_at"
     t.index ["player_id"], name: "index_playthroughs_on_player_id"
+    t.index ["started_at", "player_id"], name: "index_playthroughs_on_started_at_and_player_id"
   end
 
   add_foreign_key "playthroughs", "players"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,27 +5,32 @@ dandelion = Player.create!(name: "Dandelion")
 triss = Player.create!(name: "Triss")
 
 Playthrough.create!([
-                      { player: geralt, started_at: 1.week.ago.beginning_of_week + 1.hour, score: 150.5,
-                        time_spent: 3600.0 },
-                      { player: geralt, started_at: 2.days.ago.beginning_of_day, score: 200.0,
-                        time_spent: 3600.0 },
-                      { player: geralt, started_at: 3.weeks.ago.beginning_of_week + 3.days, score: 120.0,
-                        time_spent: 1800.0 }
+                      { player: geralt, started_at: 1.week.ago.beginning_of_week + 1.hour,
+                        score: 150.5, time_spent: 3600.0 },
+                      { player: geralt, started_at: 2.days.ago.beginning_of_day,
+                        score: 200.0, time_spent: 3600.0 },
+                      { player: geralt, started_at: 3.weeks.ago.beginning_of_week + 3.days,
+                        score: 120.0, time_spent: 1800.0 }
                     ])
 
 Playthrough.create!([
-                      { player: yennefer, started_at: 1.week.ago.beginning_of_week + 2.days + 2.hours, score: 300.0,
-                        time_spent: 5400.0 },
-                      { player: yennefer, started_at: 2.days.ago.beginning_of_day + 30.minutes, score: 400.0,
+                      { player: yennefer,
+                        started_at: 1.week.ago.beginning_of_week + 2.days + 2.hours,
+                        score: 300.0, time_spent: 5400.0 },
+                      { player: yennefer, started_at: 2.days.ago.beginning_of_day + 30.minutes,
+                        score: 400.0,
                         time_spent: 3600.0 },
-                      { player: yennefer, started_at: 4.weeks.ago.beginning_of_week + 1.day, score: 500.0,
+                      { player: yennefer, started_at: 4.weeks.ago.beginning_of_week + 1.day,
+                        score: 500.0,
                         time_spent: 7200.0 }
                     ])
 
 Playthrough.create!([
-                      { player: ciri, started_at: 3.days.ago.beginning_of_day + 3.hours, score: 500.0,
+                      { player: ciri, started_at: 3.days.ago.beginning_of_day + 3.hours,
+                        score: 500.0,
                         time_spent: 5400.0 },
-                      { player: ciri, started_at: 1.week.ago.beginning_of_week + 5.days, score: 100.0,
+                      { player: ciri, started_at: 1.week.ago.beginning_of_week + 5.days,
+                        score: 100.0,
                         time_spent: 1800.0 }
                     ])
 
@@ -35,10 +40,11 @@ Playthrough.create!([
                     ])
 
 Playthrough.create!([
-                      { player: triss, started_at: 1.week.ago.beginning_of_week + 1.day + 1.hour, score: 250.0,
+                      { player: triss, started_at: 1.week.ago.beginning_of_week + 1.day + 1.hour,
+                        score: 250.0,
                         time_spent: 2700.0 },
-                      { player: triss, started_at: 1.week.ago.beginning_of_week + 3.days + 3.hours, score: 300.0,
-                        time_spent: 3300.0 },
-                      { player: triss, started_at: 1.week.ago.beginning_of_week + 6.days + 2.hours, score: 150.0,
-                        time_spent: 1800.0 }
+                      { player: triss, started_at: 1.week.ago.beginning_of_week + 3.days + 3.hours,
+                        score: 300.0, time_spent: 3300.0 },
+                      { player: triss, started_at: 1.week.ago.beginning_of_week + 6.days + 2.hours,
+                        score: 150.0, time_spent: 1800.0 }
                     ])

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@ Playthrough.create!([
                       { player: geralt, started_at: 1.week.ago.beginning_of_week + 1.hour,
                         score: 150.5, time_spent: 3600.0 },
                       { player: geralt, started_at: 2.days.ago.beginning_of_day,
-                        score: 200.0, time_spent: 3600.0 },
+                        score: 200.0, time_spent: 7600.0 },
                       { player: geralt, started_at: 3.weeks.ago.beginning_of_week + 3.days,
                         score: 120.0, time_spent: 1800.0 }
                     ])
@@ -19,7 +19,7 @@ Playthrough.create!([
                         score: 300.0, time_spent: 5400.0 },
                       { player: yennefer, started_at: 2.days.ago.beginning_of_day + 30.minutes,
                         score: 400.0,
-                        time_spent: 3600.0 },
+                        time_spent: 3400.0 },
                       { player: yennefer, started_at: 4.weeks.ago.beginning_of_week + 1.day,
                         score: 500.0,
                         time_spent: 7200.0 }
@@ -28,23 +28,23 @@ Playthrough.create!([
 Playthrough.create!([
                       { player: ciri, started_at: 3.days.ago.beginning_of_day + 3.hours,
                         score: 500.0,
-                        time_spent: 5400.0 },
+                        time_spent: 5000.0 },
                       { player: ciri, started_at: 1.week.ago.beginning_of_week + 5.days,
                         score: 100.0,
-                        time_spent: 1800.0 }
+                        time_spent: 1200.0 }
                     ])
 
 Playthrough.create!([
                       { player: dandelion, started_at: 5.weeks.ago.beginning_of_week, score: 50.0,
-                        time_spent: 1200.0 }
+                        time_spent: 1000.0 }
                     ])
 
 Playthrough.create!([
                       { player: triss, started_at: 1.week.ago.beginning_of_week + 1.day + 1.hour,
                         score: 250.0,
-                        time_spent: 2700.0 },
+                        time_spent: 2200.0 },
                       { player: triss, started_at: 1.week.ago.beginning_of_week + 3.days + 3.hours,
-                        score: 300.0, time_spent: 3300.0 },
+                        score: 300.0, time_spent: 300.0 },
                       { player: triss, started_at: 1.week.ago.beginning_of_week + 6.days + 2.hours,
-                        score: 150.0, time_spent: 1800.0 }
+                        score: 150.0, time_spent: 100.0 }
                     ])

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,16 +1,44 @@
 geralt = Player.create!(name: "Geralt")
+yennefer = Player.create!(name: "Yennefer")
+ciri = Player.create!(name: "Ciri")
+dandelion = Player.create!(name: "Dandelion")
+triss = Player.create!(name: "Triss")
 
 Playthrough.create!([
-                      {
-                        player: geralt,
-                        started_at: 1.week.ago.beginning_of_week + 1.hour,
-                        score: 150.50,
-                        time_spent: 3600.0
-                      },
-                      {
-                        player: geralt,
-                        started_at: 2.days.ago.beginning_of_day,
-                        score: 200.00,
-                        time_spent: 3600.0
-                      }
+                      { player: geralt, started_at: 1.week.ago.beginning_of_week + 1.hour, score: 150.5,
+                        time_spent: 3600.0 },
+                      { player: geralt, started_at: 2.days.ago.beginning_of_day, score: 200.0,
+                        time_spent: 3600.0 },
+                      { player: geralt, started_at: 3.weeks.ago.beginning_of_week + 3.days, score: 120.0,
+                        time_spent: 1800.0 }
+                    ])
+
+Playthrough.create!([
+                      { player: yennefer, started_at: 1.week.ago.beginning_of_week + 2.days + 2.hours, score: 300.0,
+                        time_spent: 5400.0 },
+                      { player: yennefer, started_at: 2.days.ago.beginning_of_day + 30.minutes, score: 400.0,
+                        time_spent: 3600.0 },
+                      { player: yennefer, started_at: 4.weeks.ago.beginning_of_week + 1.day, score: 500.0,
+                        time_spent: 7200.0 }
+                    ])
+
+Playthrough.create!([
+                      { player: ciri, started_at: 3.days.ago.beginning_of_day + 3.hours, score: 500.0,
+                        time_spent: 5400.0 },
+                      { player: ciri, started_at: 1.week.ago.beginning_of_week + 5.days, score: 100.0,
+                        time_spent: 1800.0 }
+                    ])
+
+Playthrough.create!([
+                      { player: dandelion, started_at: 5.weeks.ago.beginning_of_week, score: 50.0,
+                        time_spent: 1200.0 }
+                    ])
+
+Playthrough.create!([
+                      { player: triss, started_at: 1.week.ago.beginning_of_week + 1.day + 1.hour, score: 250.0,
+                        time_spent: 2700.0 },
+                      { player: triss, started_at: 1.week.ago.beginning_of_week + 3.days + 3.hours, score: 300.0,
+                        time_spent: 3300.0 },
+                      { player: triss, started_at: 1.week.ago.beginning_of_week + 6.days + 2.hours, score: 150.0,
+                        time_spent: 1800.0 }
                     ])

--- a/spec/requests/api/v1/weekly_summary_spec.rb
+++ b/spec/requests/api/v1/weekly_summary_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::WeeklySummary", type: :request do
+  describe "GET /api/v1/weekly_summary" do
+    it "returns a successful response" do
+      get "/api/v1/weekly_summary"
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("message")
+    end
+  end
+end

--- a/spec/requests/api/v1/weekly_summary_spec.rb
+++ b/spec/requests/api/v1/weekly_summary_spec.rb
@@ -2,10 +2,67 @@ require 'rails_helper'
 
 RSpec.describe "Api::V1::WeeklySummary", type: :request do
   describe "GET /api/v1/weekly_summary" do
-    it "returns a successful response" do
+    let!(:high_score_player) { create(:player, name: "High Score Player") }
+    let!(:long_duration_player) { create(:player, name: "Long Duration Player") }
+
+    before do
+      # High Score Player: total_score = 300, total_duration = 5400
+      create(:playthrough, player: high_score_player,
+                           started_at: Date.current.beginning_of_week + 1.day, score: 100,
+                           time_spent: 1800)
+      create(:playthrough, player: high_score_player,
+                           started_at: Date.current.beginning_of_week + 2.days, score: 200,
+                           time_spent: 3600)
+
+      # Long Duration Player: total_score = 100, total_duration = 7200
+      create(:playthrough, player: long_duration_player,
+                           started_at: Date.current.beginning_of_week + 3.days, score: 100,
+                           time_spent: 7200)
+    end
+
+    it "returns sorted summaries by total_score desc by default when no date param" do # rubocop:disable RSpec/ExampleLength
       get "/api/v1/weekly_summary"
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include("message")
+
+      json = response.parsed_body
+      summaries = json['player_summaries']
+      expect(summaries.size).to eq(2)
+
+      expect(summaries.first['player_name']).to eq("High Score Player")
+      expect(summaries.first['total_score']).to eq(300.0)
+    end
+
+    it "returns sorted summaries by total_score desc with valid date param" do # rubocop:disable RSpec/ExampleLength
+      get "/api/v1/weekly_summary", params: { date: Date.current.to_s }
+      expect(response).to have_http_status(:ok)
+
+      json = response.parsed_body
+      summaries = json['player_summaries']
+      expect(summaries.size).to eq(2)
+
+      expect(summaries.first['player_name']).to eq("High Score Player")
+      expect(summaries.first['total_score']).to eq(300.0)
+    end
+
+    it "returns sorted summaries by total_duration asc" do # rubocop:disable RSpec/ExampleLength
+      get "/api/v1/weekly_summary", params: { sort_by: 'total_duration', direction: 'asc' }
+      expect(response).to have_http_status(:ok)
+
+      json = response.parsed_body
+      summaries = json['player_summaries']
+      expect(summaries.size).to eq(2)
+
+      # Long Duration Player has higher total_duration so should come last in asc order
+      expect(summaries.first['player_name']).to eq("High Score Player")
+      expect(summaries.first['total_duration']).to eq(5400.0)
+    end
+
+    it "returns 422 for invalid date format" do
+      get "/api/v1/weekly_summary", params: { date: "invalid-date" }
+      expect(response).to have_http_status(:unprocessable_entity)
+
+      json = response.parsed_body
+      expect(json['error']).to eq('Invalid date format')
     end
   end
 end

--- a/spec/services/api/v1/weekly_summary_service_spec.rb
+++ b/spec/services/api/v1/weekly_summary_service_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::WeeklySummaryService do
+  describe '.call' do
+    let(:week_start) { Date.new(2025, 1, 6) } # Monday
+    let(:week_end)   { Date.new(2025, 1, 12) } # Sunday
+
+    let!(:high_score_player)     { create(:player, name: 'High Score Player') }
+    let!(:long_duration_player)  { create(:player, name: 'Long Duration Player') }
+    let!(:balanced_player)       { create(:player, name: 'Balanced Player') }
+
+    context 'when playthroughs exist in the given week' do
+      before do
+        # High Score Player: 100 + 200 = 300 score, 1000 + 2000 = 3000 time
+        create(:playthrough, player: high_score_player, started_at: week_start.noon, score: 100,
+                             time_spent: 1000)
+        create(:playthrough, player: high_score_player, started_at: week_start + 2.days,
+                             score: 200, time_spent: 2000)
+
+        # Long Duration Player: 500 score, 3000 time
+        create(:playthrough, player: long_duration_player, started_at: week_start + 4.days,
+                             score: 500, time_spent: 3000)
+
+        # Balanced Player: 150 score, 1500 time
+        create(:playthrough, player: balanced_player, started_at: week_end.noon, score: 150,
+                             time_spent: 1500)
+
+        # Outside week — ignored
+        create(:playthrough, player: high_score_player, started_at: week_end + 1.day, score: 999,
+                             time_spent: 9999)
+        create(:playthrough, player: long_duration_player, started_at: week_start - 1.day,
+                             score: 888, time_spent: 8888)
+      end
+
+      it 'returns correct summary for a date in the middle of the week' do # rubocop:disable RSpec/ExampleLength
+        summary = described_class.call(week_start + 2.days)
+
+        expect(summary[:week_start_date]).to eq(week_start)
+        expect(summary[:week_end_date]).to eq(week_end)
+        expect(summary[:player_summaries].size).to eq(3)
+
+        expect(summary[:player_summaries]).to include(
+          a_hash_including(
+            player_name: 'High Score Player',
+            total_score: 300,
+            total_duration: 3000
+          ),
+          a_hash_including(
+            player_name: 'Long Duration Player',
+            total_score: 500,
+            total_duration: 3000
+          ),
+          a_hash_including(
+            player_name: 'Balanced Player',
+            total_score: 150,
+            total_duration: 1500
+          )
+        )
+      end
+    end
+
+    context 'when no playthroughs exist in the given week' do
+      it 'returns empty player_summaries' do
+        summary = described_class.call(Date.new(2020, 1, 1))
+        expect(summary[:player_summaries]).to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/api/v1/weekly_summary_service_spec.rb
+++ b/spec/services/api/v1/weekly_summary_service_spec.rb
@@ -2,67 +2,85 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::WeeklySummaryService do
   describe '.call' do
-    let(:week_start) { Date.new(2025, 1, 6) } # Monday
+    let(:week_start) { Date.new(2025, 1, 6) }  # Monday
     let(:week_end)   { Date.new(2025, 1, 12) } # Sunday
 
-    let!(:high_score_player)     { create(:player, name: 'High Score Player') }
-    let!(:long_duration_player)  { create(:player, name: 'Long Duration Player') }
-    let!(:balanced_player)       { create(:player, name: 'Balanced Player') }
+    let!(:high_score_player)    { create(:player, name: 'High Score Player') }
+    let!(:long_duration_player) { create(:player, name: 'Long Duration Player') }
+    let!(:balanced_player)      { create(:player, name: 'Balanced Player') }
+
+    before do
+      create_playthroughs_for_players
+    end
+
+    def create_playthroughs_for_players # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+      # High Score Player: 300 pts, 3000 sec
+      create(:playthrough, player: high_score_player, started_at: week_start.noon, score: 100,
+                           time_spent: 1000)
+      create(:playthrough, player: high_score_player, started_at: week_start + 2.days, score: 200,
+                           time_spent: 2000)
+
+      # Long Duration Player: 500 pts, 3000 sec
+      create(:playthrough, player: long_duration_player, started_at: week_start + 4.days,
+                           score: 500, time_spent: 3000)
+
+      # Balanced Player: 150 pts, 1500 sec
+      create(:playthrough, player: balanced_player, started_at: week_end.noon, score: 150,
+                           time_spent: 1500)
+
+      # Outside of week — should be ignored
+      create(:playthrough, player: high_score_player, started_at: week_end + 1.day, score: 999,
+                           time_spent: 9999)
+      create(:playthrough, player: long_duration_player, started_at: week_start - 1.day,
+                           score: 888, time_spent: 8888)
+    end
 
     context 'when playthroughs exist in the given week' do
-      before do
-        # High Score Player: 100 + 200 = 300 score, 1000 + 2000 = 3000 time
-        create(:playthrough, player: high_score_player, started_at: week_start.noon, score: 100,
-                             time_spent: 1000)
-        create(:playthrough, player: high_score_player, started_at: week_start + 2.days,
-                             score: 200, time_spent: 2000)
-
-        # Long Duration Player: 500 score, 3000 time
-        create(:playthrough, player: long_duration_player, started_at: week_start + 4.days,
-                             score: 500, time_spent: 3000)
-
-        # Balanced Player: 150 score, 1500 time
-        create(:playthrough, player: balanced_player, started_at: week_end.noon, score: 150,
-                             time_spent: 1500)
-
-        # Outside week — ignored
-        create(:playthrough, player: high_score_player, started_at: week_end + 1.day, score: 999,
-                             time_spent: 9999)
-        create(:playthrough, player: long_duration_player, started_at: week_start - 1.day,
-                             score: 888, time_spent: 8888)
-      end
-
-      it 'returns correct summary for a date in the middle of the week' do # rubocop:disable RSpec/ExampleLength
-        summary = described_class.call(week_start + 2.days)
+      it 'returns correct summary for the week' do # rubocop:disable RSpec/ExampleLength
+        summary = described_class.call(date: week_start + 2.days)
 
         expect(summary[:week_start_date]).to eq(week_start)
         expect(summary[:week_end_date]).to eq(week_end)
+
         expect(summary[:player_summaries].size).to eq(3)
 
         expect(summary[:player_summaries]).to include(
-          a_hash_including(
-            player_name: 'High Score Player',
-            total_score: 300,
-            total_duration: 3000
-          ),
-          a_hash_including(
-            player_name: 'Long Duration Player',
-            total_score: 500,
-            total_duration: 3000
-          ),
-          a_hash_including(
-            player_name: 'Balanced Player',
-            total_score: 150,
-            total_duration: 1500
-          )
+          a_hash_including(player_name: 'High Score Player', total_score: 300.0,
+                           total_duration: 3000.0),
+          a_hash_including(player_name: 'Long Duration Player', total_score: 500.0,
+                           total_duration: 3000.0),
+          a_hash_including(player_name: 'Balanced Player', total_score: 150.0,
+                           total_duration: 1500.0)
         )
+      end
+
+      it 'sorts by total_score descending by default' do
+        summary = described_class.call(date: week_start)
+        names = summary[:player_summaries].map { |ps| ps[:player_name] }
+
+        expect(names).to eq(['Long Duration Player', 'High Score Player', 'Balanced Player'])
+      end
+
+      it 'sorts by total_duration ascending' do
+        summary = described_class.call(date: week_start, sort_by: 'total_duration',
+                                       direction: 'asc')
+        names = summary[:player_summaries].map { |ps| ps[:player_name] }
+
+        expect(names).to eq(['Balanced Player', 'High Score Player', 'Long Duration Player'])
+      end
+
+      it 'sorts by total_score ascending' do
+        summary = described_class.call(date: week_start, sort_by: 'total_score', direction: 'asc')
+        names = summary[:player_summaries].map { |ps| ps[:player_name] }
+
+        expect(names).to eq(['Balanced Player', 'High Score Player', 'Long Duration Player'])
       end
     end
 
     context 'when no playthroughs exist in the given week' do
-      it 'returns empty player_summaries' do
-        summary = described_class.call(Date.new(2020, 1, 1))
-        expect(summary[:player_summaries]).to be_empty
+      it 'returns an empty player_summaries array' do
+        summary = described_class.call(date: Date.new(2020, 1, 1))
+        expect(summary[:player_summaries]).to eq([])
       end
     end
   end


### PR DESCRIPTION
Weekly Summary API Endpoint

- Added a new endpoint:
` /api/v1/weekly_summary` that returns aggregated weekly player stats (total score and total duration) based on playthroughs.
- Added index on `started_at` and `player_id` for performance


