### PR TITLE
Impact report

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,31 @@ Weekly Summary with `date`, sort by `total_score` or `total_duration`
     }
 ```
 
+### Get Impact Report
+
+**GET** `/api/v1/impact_report`
+
+Returns a list of all players with their impact score — defined as the difference between the first recorded score and the best recorded score in their history, sorted in descending order by highest impact.
+
+**Example CURL:**
+
+```bash
+    curl http://localhost:3000/api/v1/impact_report
+```
+
+**Response:**
+
+```json
+    [
+    {
+        "player_id": "04cd7c11-1adf-4928-a08e-3f3165fb2e03",
+        "player_name": "Consistent Improver",
+        "first_score": 100.0,
+        "best_score": 300.0,
+        "impact": 200.0
+    }]
+```
+
 ## Testing
 
 Run tests with:

--- a/app/blueprints/api/v1/impact_report_blueprint.rb
+++ b/app/blueprints/api/v1/impact_report_blueprint.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class ImpactReportBlueprint < Blueprinter::Base
+      fields :player_id, :player_name, :first_score, :best_score, :impact
+    end
+  end
+end

--- a/app/controllers/api/v1/impact_report_controller.rb
+++ b/app/controllers/api/v1/impact_report_controller.rb
@@ -1,0 +1,10 @@
+module Api
+  module V1
+    class ImpactReportController < Api::V1::BaseController
+      def index
+        report = Api::V1::ImpactReportService.call
+        render json: Api::V1::ImpactReportBlueprint.render(report)
+      end
+    end
+  end
+end

--- a/app/services/api/v1/impact_report_service.rb
+++ b/app/services/api/v1/impact_report_service.rb
@@ -1,0 +1,77 @@
+module Api
+  module V1
+    class ImpactReportService
+      def self.call
+        new.call
+      end
+
+      def call
+        player_data = collect_players_data
+        calculate_and_sort_impact(player_data)
+      end
+
+      private
+
+      def collect_players_data
+        player_ids = Player.joins(:playthroughs).distinct.pluck(:id)
+
+        first_scores = find_first_scores(player_ids)
+        best_scores = find_best_scores(player_ids)
+
+        players = Player.where(id: player_ids).index_by(&:id)
+
+        {
+          players: players,
+          first_scores: first_scores,
+          best_scores: best_scores,
+          player_ids: player_ids
+        }
+      end
+
+      def find_first_scores(player_ids)
+        scores = {}
+
+        Playthrough.select("DISTINCT ON (player_id) player_id, score")
+                   .where(player_id: player_ids)
+                   .order("player_id, started_at ASC, id ASC")
+                   .each do |pt|
+          scores[pt.player_id] = pt.score.to_f
+        end
+
+        scores
+      end
+
+      def find_best_scores(player_ids)
+        Playthrough.where(player_id: player_ids)
+                   .group(:player_id)
+                   .maximum(:score)
+                   .transform_values(&:to_f)
+      end
+
+      def calculate_and_sort_impact(data) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+        players = data[:players]
+        first_scores = data[:first_scores]
+        best_scores = data[:best_scores]
+        player_ids = data[:player_ids]
+
+        # Calculate impact for each player
+        impact_data = player_ids.map do |player_id|
+          player = players[player_id]
+          first_score = first_scores[player_id]
+          best_score = best_scores[player_id]
+          impact = best_score - first_score
+
+          {
+            player_id: player_id,
+            player_name: player.name,
+            first_score: first_score,
+            best_score: best_score,
+            impact: impact
+          }
+        end
+
+        impact_data.sort_by { |player| -player[:impact] }
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get 'weekly_summary', to: 'weekly_summary#index'
+      get 'impact_report', to: 'impact_report#index'
     end
   end
 end

--- a/spec/factories/playthroughs.rb
+++ b/spec/factories/playthroughs.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :playthrough do
     association :player
-    started_at { 2.days.ago }
+    sequence(:started_at) { |n| Time.current - n.days }
     score { BigDecimal("31.56") }
     time_spent { 3600.0 }
   end

--- a/spec/requests/api/v1/impact_report_spec.rb
+++ b/spec/requests/api/v1/impact_report_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe 'Impact Report API', type: :request do
+  describe 'GET /api/v1/impact_report' do
+    let!(:improving_player) { create(:player, name: 'Improving Player') }
+    let!(:static_player)    { create(:player, name: 'Static Player') }
+    let!(:declining_player) { create(:player, name: 'Declining Player') }
+    let!(:no_data_player)   { create(:player, name: 'No Data Player') } # bez playthroughów # rubocop:disable RSpec/LetSetup
+
+    before do
+      # Improving Player: first_score = 100, best_score = 200, impact = 100
+      create(:playthrough, player: improving_player, score: 100, started_at: 3.days.ago)
+      create(:playthrough, player: improving_player, score: 200, started_at: 1.day.ago)
+
+      # Static Player: impact = 0
+      create(:playthrough, player: static_player, score: 150, started_at: 2.days.ago)
+
+      # Declining Player: first_score = 150, best_score = 150, impact = 0
+      create(:playthrough, player: declining_player, score: 150, started_at: 3.days.ago)
+      create(:playthrough, player: declining_player, score: 100, started_at: 1.day.ago)
+
+      # No Data Player: brak playthroughów
+    end
+
+    it 'returns a successful response with expected structure' do # rubocop:disable RSpec/ExampleLength
+      get '/api/v1/impact_report'
+
+      expect(response).to have_http_status(:ok)
+
+      json = response.parsed_body
+
+      expect(json).to be_an(Array)
+
+      expect(json.first.keys).to match_array(%w[player_id player_name first_score best_score
+                                                impact])
+    end
+
+    it 'returns players sorted by descending impact' do
+      get '/api/v1/impact_report'
+
+      json = response.parsed_body
+      expect(json.first['player_name']).to eq('Improving Player')
+
+      remaining_names = json.drop(1).map { |entry| entry['player_name'] }
+      expect(remaining_names).to contain_exactly('Static Player', 'Declining Player')
+    end
+
+    it 'calculates correct impact values' do # rubocop:disable RSpec/ExampleLength
+      get '/api/v1/impact_report'
+
+      json = response.parsed_body
+      player_data = json.index_by { |entry| entry['player_name'] }
+
+      expect(player_data['Improving Player']['impact']).to eq(100.0)
+      expect(player_data['Static Player']['impact']).to eq(0.0)
+      expect(player_data['Declining Player']['impact']).to eq(0.0)
+    end
+
+    it 'does not include players without playthroughs' do
+      get '/api/v1/impact_report'
+
+      json = response.parsed_body
+      names = json.map { |entry| entry['player_name'] }
+
+      expect(names).not_to include('No Data Player')
+    end
+  end
+end

--- a/spec/services/api/v1/impact_report_service_spec.rb
+++ b/spec/services/api/v1/impact_report_service_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::ImpactReportService do
+  describe '.call' do
+    let!(:consistent_improver) { create(:player, name: 'Consistent Improver') }
+    let!(:moderate_progress)   { create(:player, name: 'Moderate Progress') }
+    let!(:no_progress)         { create(:player, name: 'No Progress') }
+    let!(:declining_player)    { create(:player, name: 'Declining Player') }
+    let!(:inactive_player)     { create(:player, name: 'Inactive Player') } # no playthroughs # rubocop:disable RSpec/LetSetup
+
+    before do
+      # Consistent Improver: first_score = 100, best_score = 300, impact = 200
+      create(:playthrough, player: consistent_improver, score: 100, started_at: 3.days.ago)
+      create(:playthrough, player: consistent_improver, score: 300, started_at: 1.day.ago)
+
+      # Moderate Progress: first_score = 150, best_score = 250, impact = 100
+      create(:playthrough, player: moderate_progress, score: 150, started_at: 4.days.ago)
+      create(:playthrough, player: moderate_progress, score: 250, started_at: 2.days.ago)
+
+      # No Progress: only 1 playthrough, first_score = best_score = 180, impact = 0
+      create(:playthrough, player: no_progress, score: 180, started_at: 2.days.ago)
+
+      # Declining Player: first_score = 200, best_score = 200, impact = 0
+      # + one lower score later, best_score stays 200, impact = 0
+      create(:playthrough, player: declining_player, score: 200, started_at: 3.days.ago)
+      create(:playthrough, player: declining_player, score: 150, started_at: 1.day.ago)
+    end
+
+    it 'returns players sorted by highest impact' do # rubocop:disable RSpec/ExampleLength
+      result = described_class.call
+
+      expect(result.length).to eq(4)
+
+      impacts = result.map { |r| r[:impact] }
+      expect(impacts).to eq(impacts.sort.reverse)
+
+      players = result.index_by { |r| r[:player_name] }
+
+      expect(players['Consistent Improver']).to include(
+        first_score: 100.0,
+        best_score: 300.0,
+        impact: 200.0
+      )
+
+      expect(players['Moderate Progress']).to include(
+        first_score: 150.0,
+        best_score: 250.0,
+        impact: 100.0
+      )
+
+      expect(players['No Progress']).to include(
+        first_score: 180.0,
+        best_score: 180.0,
+        impact: 0.0
+      )
+
+      expect(players['Declining Player']).to include(
+        first_score: 200.0,
+        best_score: 200.0,
+        impact: 0.0
+      )
+    end
+
+    it 'excludes players without any playthroughs' do
+      names = described_class.call.map { |r| r[:player_name] }
+      expect(names).not_to include('Inactive Player')
+    end
+
+    it 'returns expected keys in each result' do
+      result = described_class.call.first
+      expect(result.keys).to match_array(%i[player_id player_name first_score best_score impact])
+    end
+  end
+end


### PR DESCRIPTION
Add Impact Report API endpoint

* Implements a new GET `/api/v1/impact_report` endpoint.
* Returns a list of all players with their impact calculated as the difference between their first and best recorded scores.
* Results are sorted descending by impact to highlight top improvers.
